### PR TITLE
fixed: Add command to create build directory in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ compile: versiontag
 # xeus-based kernel
 #	python -m jupyter lite build --XeusPythonEnv.packages=numpy,matplotlib,ipyleaflet,scipy,pandas,scikit-learn,scikit-image,networkx --lite-dir=build
 #	cp ./overrides.json ./build
+	mkdir build
 	cp ./jupyter-lite.json ./build
 	python -m jupyter lite build --lite-dir build
 #	python -m jupyter lite init --lite-dir build --contents ./quiz

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ compile: versiontag
 # xeus-based kernel
 #	python -m jupyter lite build --XeusPythonEnv.packages=numpy,matplotlib,ipyleaflet,scipy,pandas,scikit-learn,scikit-image,networkx --lite-dir=build
 #	cp ./overrides.json ./build
-	mkdir build
+	mkdir -p build
 	cp ./jupyter-lite.json ./build
 	python -m jupyter lite build --lite-dir build
 #	python -m jupyter lite init --lite-dir build --contents ./quiz


### PR DESCRIPTION
- Bug that recognizes the build directory as a file

```
$ (venv) ➜  snakebarrel git:(fixed/Makefile) ✗ make linux
	...
PythonAction Error
Traceback (most recent call last):
  File "/home/sd/works/snakebarrel/venv/lib/python3.10/site-packages/doit/action.py", line 461, in execute
    returned_value = self.py_callable(*self.args, **kwargs)
  File "/home/sd/works/snakebarrel/venv/lib/python3.10/site-packages/doit/tools.py", line 20, in create_folder
    os.makedirs(dir_path, exist_ok=True)
  File "/usr/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
NotADirectoryError: [Errno 20] Not a directory: '/home/sd/works/snakebarrel/build/_output'

make[1]: *** [Makefile:26: compile] Error 2
make[1]: Leaving directory '/home/sd/works/snakebarrel'
make: *** [Makefile:30: dep] Error 2
```

- After creating the build directory, add a directory creation command to proceed with make

```
$ (venv) ➜  snakebarrel git:(fixed/Makefile) ✗ make linux
	...

[BUILD] Done.

cd app; zip -r -9 ./SnakeBarrel-linux-x64-221004.zip "./SnakeBarrel-linux-x64"

[BUILD] Done.

	...

cd app; zip -r -9 ./SnakeBarrel-linux-arm64-221004.zip "./SnakeBarrel-linux-arm64"

mv ./app/SnakeBarrel-linux-arm64-221004.zip ./app/SnakeBarrel-0.1.0-linux-arm64.zip
```

* System: Linux sd-amd3600 5.15.0-48-generic #54-Ubuntu SMP Fri Aug 26 13:26:29 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux

Thx!